### PR TITLE
Fix the command fails to parse a remote url when it does not start with ssh://

### DIFF
--- a/bin/git-diff-prs
+++ b/bin/git-diff-prs
@@ -45,6 +45,7 @@ def repository
   @repository ||= begin
     remote = git(:config, 'remote.origin.url').first.chomp
 
+    remote = "ssh://#{remote.sub(':', '/')}" unless remote == %r{^\w+://}
     remote_url = URI.parse(remote)
     remote_url.path.sub(%r{^/}, '').sub(/\.git$/, '')
   end


### PR DESCRIPTION
The command fails to parse `remote.origin.url` if it does not start with 'ssh://' like 'git@github.com/mitene/git-diff-prs'.  This change fixes the issue.