### PR TITLE
Fix the previous fix caused a regression

### DIFF
--- a/bin/git-diff-prs
+++ b/bin/git-diff-prs
@@ -45,7 +45,7 @@ def repository
   @repository ||= begin
     remote = git(:config, 'remote.origin.url').first.chomp
 
-    remote = "ssh://#{remote.sub(':', '/')}" unless remote == %r{^\w+://}
+    remote = "ssh://#{remote.sub(':', '/')}" unless remote =~ %r{^\w+://}
     remote_url = URI.parse(remote)
     remote_url.path.sub(%r{^/}, '').sub(/\.git$/, '')
   end


### PR DESCRIPTION
The previous fix #1 introduced a regression that the command failed to parse a remote url starts with 'ssh://'.  The change fixes that issue.  My bad.