### PR TITLE
Specify the latest Octokit version.

### DIFF
--- a/git-diff-prs.gemspec
+++ b/git-diff-prs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'octokit', '~> 0'
+  spec.add_dependency 'octokit', '~> 4.13'
 
   spec.license = 'MIT'
 end


### PR DESCRIPTION
# Background
In some environment, the command failed to run due to an error like `MultiJson::DecodeError` or `undefined method `dump' for class `#<Class:MultiJson>'`.

To fix the problems, I am specifying the dependency for Octokit.